### PR TITLE
Fixed `proplist_to_record` macro, added point_to_point example, fixed version to 1.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ See [examples](./examples).
 
     $ make doc
 
+> **Note:** Once you run previous command, a new folder `doc` is created, and you'll have a pretty nice HTML documentation.
+
 
 ## Change Log
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,5 +4,7 @@ ErlBus Examples
 
  *  [pubsub](./pubsub):
     basic example to show the use of Pub/Sub pattern.
+ *  [point_to_point](./point_to_point):
+    basic example to show how to implement a point-to-point pattern.
  *  [chat](./chat):
     basic chat example using websockets.

--- a/examples/point_to_point/Makefile
+++ b/examples/point_to_point/Makefile
@@ -19,4 +19,4 @@ distclean: clean
 	rm -rf _build *.lock
 
 run: all
-	erl -pa $(BUILD_PATH) -s pubsub -config ${CONFIG}
+	erl -pa $(BUILD_PATH) -s point_to_point -config ${CONFIG}

--- a/examples/point_to_point/README.md
+++ b/examples/point_to_point/README.md
@@ -1,0 +1,16 @@
+Point-To-Point example
+======================
+
+To try this example, you need GNU `make` and `git` in your PATH.
+
+To build the example, run the following command:
+
+``` bash
+$ make
+```
+
+To start the example:
+
+``` bash
+$ make run
+```

--- a/examples/point_to_point/config/sys.config
+++ b/examples/point_to_point/config/sys.config
@@ -1,0 +1,14 @@
+[
+ %% EBus
+ {ebus,
+  [
+   {pubsub,
+    [
+     {adapter, ebus_ps_pg2},
+     {pool_size, 5},
+     {name, ebus_ps}
+    ]
+   }
+  ]
+ }
+].

--- a/examples/point_to_point/rebar.config
+++ b/examples/point_to_point/rebar.config
@@ -1,0 +1,10 @@
+%% Erlang compiler options
+{erl_opts, [debug_info, fail_on_warning]}.
+
+%% Whether to enable coverage reporting. Default is `false'
+{cover_enabled, true}.
+
+%% Dependencies
+{deps, [
+  {erlbus, {git, "https://github.com/cabol/erlbus.git", {branch, "master"}}}
+]}.

--- a/examples/point_to_point/src/point_to_point.app.src
+++ b/examples/point_to_point/src/point_to_point.app.src
@@ -1,0 +1,19 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+{application, point_to_point,
+ [
+  {description, "ErlBus Point-To-Point example."},
+  {vsn, "1"},
+  {modules, []},
+  {registered, []},
+  {applications,
+   [
+    kernel,
+    stdlib,
+    ebus
+   ]
+  },
+  {mod, {point_to_point, []}},
+  {env, []}
+ ]
+}.

--- a/examples/point_to_point/src/point_to_point.erl
+++ b/examples/point_to_point/src/point_to_point.erl
@@ -1,0 +1,51 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(point_to_point).
+
+-behaviour(application).
+
+%% API.
+-export([start/0, start/2]).
+-export([stop/0, stop/1]).
+
+-define(TOPIC, <<"P2P_TOPIC">>).
+
+%% API.
+
+start() ->
+  application:ensure_all_started(point_to_point).
+
+start(_Type, _Args) ->
+  P = spawn_link(fun() -> dispatcher(?TOPIC) end),
+  lists:foreach(fun(N) -> subscriber(?TOPIC, N) end, lists:seq(1, 3)),
+  timer:sleep(1 * 60 * 1000),
+  exit(P, kill),
+  teardown_ebus().
+
+stop() ->
+  application:stop(point_to_point).
+
+stop(_State) ->
+  ok.
+
+%% Internals
+
+dispatcher(Topic) ->
+  timer:sleep(500),
+  Msg = #{topic => Topic, payload => os:timestamp()},
+  io:format("Dispatch: ~p~n", [Msg]),
+  ebus:dispatch(Topic, Msg),
+  dispatcher(Topic).
+
+subscriber(Topic, N) ->
+  Callback = fun(Ctx, Msg) ->
+    io:format(
+      "\e[36m---> [PID: ~p][CTX: ~p][MSG: ~p]~n\e[0m",
+      [self(), Ctx, Msg]
+    )
+  end,
+  {Handler, _} = ebus_process:spawn_handler(Callback, N, [monitor]),
+  ebus:sub(Handler, Topic).
+
+teardown_ebus() ->
+  application:stop(ebus).

--- a/include/ebus.hrl
+++ b/include/ebus.hrl
@@ -92,11 +92,17 @@
     [Tag | Values] = tuple_to_list(Tuple),
     Defaults = lists:zip(Fields, Values),
     F = fun({K, V}) ->
-          case lists:keyfind(K, 1, Proplist) of
-            {_K, V0} -> V0;
-            _        -> V
+      case lists:keyfind(K, 1, Proplist) of
+        {K, V0} ->
+          V0;
+        _ ->
+          BinK = atom_to_binary(K, utf8),
+          case lists:keyfind(BinK, 1, Proplist) of
+            {BinK, V1} -> V1;
+            _       -> V
           end
-        end,
+      end
+    end,
     L = lists:map(F, Defaults),
     list_to_tuple([Tag | L])
   end

--- a/src/ebus.app.src
+++ b/src/ebus.app.src
@@ -1,7 +1,7 @@
 {application, ebus,
  [
   {description, "Erlang Message Event Bus"},
-  {vsn, "0.2.0"},
+  {vsn, "1.0.0"},
   {id, "git"},
   {modules, []},
   {registered, []},


### PR DESCRIPTION
- Fixed `proplist_to_record` to fetch atom/binary keys.
- Added point_to_point example.
- Fixed version to 1.0.0.
