### PR TITLE
[#38] – Fix tests to use rebar3 directly instead of call ct_run

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,22 @@
 %% == Erlang Compiler ==
 
-{erl_opts, [debug_info, warnings_as_errors]}.
+{erl_opts, [
+  debug_info,
+  warnings_as_errors,
+  warn_unused_vars,
+  ewarn_export_all,
+  warn_shadow_vars,
+  warn_unused_import,
+  warn_unused_function,
+  warn_bif_clash,
+  warn_unused_record,
+  warn_deprecated_function,
+  warn_obsolete_guard,
+  strict_validation,
+  warn_export_vars,
+  warn_exported_vars,
+  warn_untyped_record
+]}.
 
 %% == Cover ==
 
@@ -10,14 +26,51 @@
 
 {deps, []}.
 
-%% == Profiles ==
+%% == Common Test ==
 
-{profiles, [
-  {debug, [
-    {erl_opts, [debug_info, warnings_as_errors]},
-    {deps, [
-      {recon, {git, "https://github.com/ferd/recon.git", {branch, "master"}}},
-      {eper, {git, "https://github.com/massemanet/eper.git", {tag, "0.97.1"}}}
-    ]}
-  ]}
+{ct_compile_opts, [
+  debug_info,
+  warnings_as_errors,
+  warn_unused_vars,
+  ewarn_export_all,
+  warn_shadow_vars,
+  warn_unused_import,
+  warn_unused_function,
+  warn_bif_clash,
+  warn_unused_record,
+  warn_deprecated_function,
+  warn_obsolete_guard,
+  strict_validation,
+  warn_export_vars,
+  warn_exported_vars,
+  warn_untyped_record
+]}.
+
+{ct_opts, [
+  {sys_config, ["test/test.config"]}
+]}.
+
+%% == EDoc ==
+
+{edoc_opts, []}.
+
+%% == Shell ==
+
+{shell, [{apps, [ebus]}]}.
+
+%% == Dialyzer ==
+
+{dialyzer, [
+  {warnings, [
+    race_conditions,
+    no_return,
+    unmatched_returns,
+    error_handling
+  ]},
+  {plt_apps, top_level_deps},
+  {plt_extra_apps, []},
+  {plt_location, local},
+  {plt_prefix, "ebus"},
+  {base_plt_location, "."},
+  {base_plt_prefix, "ebus"}
 ]}.

--- a/src/ebus.app.src
+++ b/src/ebus.app.src
@@ -1,10 +1,13 @@
 {application, ebus, [
-  {description, "ErlBus: Erlang Message Event Bus"},
-  {vsn, "0.2.0"},
+  {description, "Erlang Message Event Bus"},
+  {vsn, "0.2.1"},
   {id, "ebus"},
   {modules, []},
   {registered, []},
-  {applications, [kernel, stdlib]},
+  {applications, [
+    kernel,
+    stdlib
+  ]},
   {mod, {ebus, []}},
   {env, []},
   {maintainers, ["Carlos Andres Bolanos"]},

--- a/test/ebus_handler_SUITE.erl
+++ b/test/ebus_handler_SUITE.erl
@@ -26,6 +26,7 @@
 all() -> [t_handler, t_callback_handler].
 
 init_per_suite(Config) ->
+  ebus:stop(),
   ebus:start(),
   Config.
 


### PR DESCRIPTION
[#38] – Fix tests to use rebar3 directly instead of call ct_run